### PR TITLE
New release versioning

### DIFF
--- a/deploy-release.sh
+++ b/deploy-release.sh
@@ -21,4 +21,4 @@ sed -i 's/-SNAPSHOT<\/version>/<\/version>/' pom.xml
 mvn clean deploy -U
 
 # Regardless of what happened, restore original pom.xml
-mv pom.xml.backup pm.xml
+mv pom.xml.backup pom.xml

--- a/deploy-release.sh
+++ b/deploy-release.sh
@@ -1,0 +1,24 @@
+# This shell script is used to automate the process of deploying a stable
+# release version (i.e. one in which the version does not end in -SNAPSHOT).
+# Further discussion may be found on the RTW wiki.
+
+# Save a copy of pom.xml, which we will be temporarily modifying
+cp pom.xml pom.xml.backup
+
+# Switch dependences over to release versions.  This ensures that all stable
+# releases build against other stable releases.
+
+# We may want to switch to a less hamfisted way of doing this, like looking
+# only in the dependency section and picking out only things in edu.cmu.ml.rtw
+# or that are somehow marked as being our own internal dependencies.  But
+# we'll start quick and simple.
+
+# Note that this conveniently also removes -SNAPSHOT from the version of this
+# project as well.
+sed -i 's/-SNAPSHOT<\/version>/<\/version>/' pom.xml
+
+# Rebuild and deploy.  This will fail to deploy if the build fails.
+mvn clean deploy -U
+
+# Regardless of what happened, restore original pom.xml
+mv pom.xml.backup pm.xml

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>edu.cmu.ml.rtw</groupId>
   <artifactId>micro-hdp</artifactId>
   <packaging>nar</packaging>
-  <version>0.0.1</version>
+  <version>0.0.1-SNAPSHOT</version>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <groupId>edu.cmu.ml.rtw</groupId>
   <artifactId>micro-hdp</artifactId>
   <packaging>nar</packaging>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.0.1</version>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>edu.cmu.ml.rtw</groupId>
       <artifactId>micro-util</artifactId>
-      <version>0.0.2-SNAPSHOT</version>
+      <version>0.0.4</version>
     </dependency>
   </dependencies>
   <repositories>      
@@ -96,10 +96,15 @@
     </repository>
   </repositories>
   <distributionManagement>
-  	<repository>
+    <snapshotRepository>
       <id>rtw-libs-snapshot</id>
       <name>rtw-libs-snapshot</name>
       <url>dav:http://rtw.ml.cmu.edu:8081/artifactory/libs-snapshot-local</url>
+    </snapshotRepository>
+    <repository>
+      <id>rtw-libs</id>
+      <name>rtw-libs-releases</name>
+      <url>dav:http://rtw.ml.cmu.edu:8081/artifactory/libs-release-local</url>
     </repository>
   </distributionManagement>
 </project>


### PR DESCRIPTION
Switched pom.xml to depend on release (stable) versions of dependencies as new standard.  deploy-release.sh automates the process of releasing a new stable version of micro-hdp.
